### PR TITLE
fix up window.AudioContext in case of prefixing

### DIFF
--- a/browser-entry.js
+++ b/browser-entry.js
@@ -1,3 +1,6 @@
+// fix up in case of browser vendor prefixing
+window.AudioContext = window.AudioContext || window.webkitAudioContext
+
 var insertCss = require('insert-css')
 var watch = require('observ/watch')
 


### PR DESCRIPTION
quick attempt at fixing https://github.com/mmckegg/web-audio-school/issues/7, except i don't have Safari available to test.

/cc @mmckegg @herrherrmann
