### PR TITLE
#2: simply added error message to the player view

### DIFF
--- a/styles/player.mcss
+++ b/styles/player.mcss
@@ -32,8 +32,8 @@ Player {
       background: #372222;
       color: #F58F8F;
 
-      :after {
-        content: ": code error :("
+      :before {
+        content: "code error :( "
         color: white
         font-weight: normal
       }

--- a/views/lesson.js
+++ b/views/lesson.js
@@ -144,6 +144,7 @@ function LessonView (state, lesson) {
 
   function verify () {
     player.classList.remove('-error')
+    player.firstChild.innerHTML = 'Your Audio' // reset audio/error message
 
     verifier.verify(function (err, pass) {
       player.classList.remove('-playing')
@@ -153,6 +154,7 @@ function LessonView (state, lesson) {
       if (err) {
         player.classList.add('-error')
         if (err instanceof Error) {
+          player.firstChild.innerHTML = err.message;
           console.log(err.message + '\n' + err.stack)
         } else {
           console.log(err)


### PR DESCRIPTION
I always get the `code error` messages when playing with this tutorial and it' hard to find what exactly the error is (mostly typos).

So I made these simple changes to indicate the error message.

* move 'code error' message in `player.mcss` from `after` to `before`
* Change `Your Audio` to error message in `.player` -> `header`, once there is an error in the editor.