### PR TITLE
use `opn` for cross-os compatibility. fixes #21

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "micro-css": "^0.5.0",
     "observ": "^0.2.0",
     "observ-struct": "^6.0.0",
+    "opn": "^5.1.0",
     "stereo-panner-node": "~0.2.0",
     "through2": "^0.6.5"
   },

--- a/run.js
+++ b/run.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 var exec = require('child_process').exec
+var opn = require('opn');
 
 process.chdir(__dirname)
 var runner = exec('npm start')
@@ -7,7 +8,7 @@ var runner = exec('npm start')
 console.log('Starting server...')
 setTimeout(function () {
   console.log('Go to http://localhost:9966')
-  exec('open http://localhost:9966')
+  opn('http://localhost:9966')
   runner.stdout.pipe(process.stdout)
   runner.stderr.pipe(process.stderr)
 }, 2000)


### PR DESCRIPTION
See #21 